### PR TITLE
Disable provenance attestations on staging image

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,6 +53,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_SHA=${{ github.sha }}
+          provenance: false
           no-cache: true
 
   deploy:


### PR DESCRIPTION
## Summary
- Root cause of stale deploys: `docker pull` on the VPS fails with "denied" because buildx provenance attestations create an OCI image index with an `unknown/unknown` platform manifest
- Fix: set `provenance: false` in `docker/build-push-action` to push a plain image manifest

## Context
The VPS can't pull any recently pushed images — `docker pull ghcr.io/astralprotocol/astral-location-services:latest` returns "denied". The repo and package are both public. The issue is that the attestation manifest confuses unauthenticated pulls.

## Test plan
- [ ] After merge+deploy, verify `docker pull` succeeds on VPS
- [ ] Verify `curl https://staging-api.astral.global/ | jq .commit` returns the SHA